### PR TITLE
Lcl list fix

### DIFF
--- a/core/src/com/sasluca/lcl/utils/collections/list/LCLList.java
+++ b/core/src/com/sasluca/lcl/utils/collections/list/LCLList.java
@@ -82,8 +82,8 @@ public class LCLList<OBJECT> implements IList<OBJECT>
 
     @Override public LCLList<OBJECT> clean()
     {
-        private Array<OBJECT> cleaned_m_Array = new Array<>();
-        private LCLString cleaned_m_Erasables = new LCLString("");
+        Array<OBJECT> cleaned_m_Array = new Array<>();
+        LCLString cleaned_m_Erasables = new LCLString("");
         for (int i = 0; i < m_Array.getLength(); i++)
         {
             if (m_Erasables.getCharAt(i) == '0')

--- a/core/src/com/sasluca/lcl/utils/collections/list/LCLList.java
+++ b/core/src/com/sasluca/lcl/utils/collections/list/LCLList.java
@@ -35,7 +35,7 @@ public class LCLList<OBJECT> implements IList<OBJECT>
 
     @Override public LCLList<OBJECT> remove(OBJECT object)
     {
-        m_Array.indexOf(object, false);
+        m_Erasables.deleteCharAt(m_Array.indexOf(object, false));
         m_Array.removeValue(object, false);
 
         return this;

--- a/core/src/com/sasluca/lcl/utils/collections/list/LCLList.java
+++ b/core/src/com/sasluca/lcl/utils/collections/list/LCLList.java
@@ -82,17 +82,18 @@ public class LCLList<OBJECT> implements IList<OBJECT>
 
     @Override public LCLList<OBJECT> clean()
     {
-        for (int i = 0; i < m_Erasables.getLength(); i++)
+        private Array<OBJECT> cleaned_m_Array = new Array<>();
+        private LCLString cleaned_m_Erasables = new LCLString("");
+        for (int i = 0; i < m_Array.getLength(); i++)
         {
-            if(m_Erasables.getLength() == 0) break;
-            if (m_Erasables.getCharAt(i) == '1')
+            if (m_Erasables.getCharAt(i) == '0')
             {
-                m_Array.removeIndex(i);
-                m_Erasables.deleteCharAt(i);
-                i--;
+                cleaned_m_Array.add(m_Array.get(i));
+                cleaned_m_Erasables.append('0');
             }
         }
-
+        m_Erasables = cleaned_m_Erasables;
+        m_Array = cleaned_m_Array;
         return this;
     }
 


### PR DESCRIPTION
Fixed mistake here: public LCLList<OBJECT> remove(OBJECT object) (Item wasn't removed from
the m_Erasables LCLString).
Made clean method run better.

Disclaimer: I might even have syntax error since I haven't configured the project yet. 
